### PR TITLE
Missing definition of M_PI on MinGW targets.

### DIFF
--- a/vmmlib/math.hpp
+++ b/vmmlib/math.hpp
@@ -34,6 +34,10 @@
 
 #include <cmath>
 
+#ifndef M_PI
+#	define M_PI 3.14159265358979323846
+#endif
+
 namespace vmml
 {
 


### PR DESCRIPTION
When compiling projects that depend on vmmlib with MinGW64 (v3.2.0), the `M_PI` macro is not defined.
This patch defines `M_PI` in `vmmlib/math.hpp` after the inclusion of `cmath`, where `M_PI` is usually defined in other compile environments.
