### PR TITLE
Add missing include header on vector.hpp

### DIFF
--- a/vmmlib/vector.hpp
+++ b/vmmlib/vector.hpp
@@ -41,6 +41,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <stdexcept>
 #include <stdint.h>
 #include <string>
 #include <vector>


### PR DESCRIPTION
missing header triggering compilation error on recent GCC inside Brion